### PR TITLE
Handle case when server response with non-200 code

### DIFF
--- a/src/marketdata/download_md.sh
+++ b/src/marketdata/download_md.sh
@@ -24,6 +24,9 @@ function download {
       echo 'invalid token'
       exit 1
   fi
+#В случае другой ошибки - просто напишем ее в консоль и выйдем
+  echo "unspecified error with code: ${response_code}"
+  exit 1
 }
 
 while read -r figi; do


### PR DESCRIPTION
I got an error 400 for my curl-request, and still received exit_code 0 from script, which is really confusing.

Handled that case by more simple way